### PR TITLE
fix: update message status icon sizes and colors for better visibility

### DIFF
--- a/client/components/ui/Messages/MessageDetails/Conversation.tsx
+++ b/client/components/ui/Messages/MessageDetails/Conversation.tsx
@@ -39,31 +39,31 @@ export default function Conversation({
       case 'sending':
         return (
           <div className="flex items-center">
-            <Check className="h-3 w-3 text-white/50" />
+            <Check className="h-4 w-4 text-white/60" />
           </div>
         );
       case 'delivered':
         return (
           <div className="flex items-center">
-            <Check className="h-3 w-3 text-gray-400" />
-            <Check className="h-3 w-3 text-gray-400 -ml-1" />
+            <Check className="h-4 w-4 text-white/80" />
+            <Check className="h-4 w-4 text-white/80 -ml-1" />
           </div>
         );
       case 'seen':
         return (
           <div className="flex items-center">
-            <Check className="h-3 w-3 text-blue-500 font-bold" />
-            <Check className="h-3 w-3 text-blue-500 font-bold -ml-1" />
+            <Check className="h-4 w-4 text-green-400 font-bold" />
+            <Check className="h-4 w-4 text-green-400 font-bold -ml-1" />
           </div>
         );
       case 'failed':
-        return <X className="h-3 w-3 text-red-400" />;
+        return <X className="h-4 w-4 text-red-400" />;
       default:
         // Show default delivered status for outgoing messages without explicit status
         return (
           <div className="flex items-center">
-            <Check className="h-3 w-3 text-gray-300" />
-            <Check className="h-3 w-3 text-gray-300 -ml-1" />
+            <Check className="h-4 w-4 text-white/80" />
+            <Check className="h-4 w-4 text-white/80 -ml-1" />
           </div>
         );
     }
@@ -139,7 +139,7 @@ export default function Conversation({
             key={stableKey}
             className={cn(
               "flex",
-              message.isIncoming ? "justify-center" : "justify-end"
+              message.isIncoming ? "justify-start" : "justify-end"
             )}
           >
             {/* Message bubble  */}


### PR DESCRIPTION
This pull request updates the `Conversation` component in `client/components/ui/Messages/MessageDetails/Conversation.tsx` to enhance the visual appearance of message status icons and improve the alignment of incoming messages.

### Visual updates to message status icons:
* Increased the size of the status icons from `h-3 w-3` to `h-4 w-4` for better visibility.
* Updated the colors of the icons to improve contrast and clarity:
  - `sending`: Changed color to `text-white/60`.
  - `delivered`: Changed color to `text-white/80`.
  - `seen`: Changed color to `text-green-400`.
  - [`failed`](diffhunk://#diff-767dcc6236d23bcb105660ec81fe613898b0f4798d564435bac09bb5d86c0ca7L42-R66): Retained `text-red-400`.

### Alignment improvement for incoming messages:
* Adjusted the alignment of incoming messages from `justify-center` to `justify-start` for better positioning within the UI.